### PR TITLE
[WIP]自動デプロイ作業

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,10 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
+group :production do
+  gem 'unicorn', '5.4.1'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'gretel'


### PR DESCRIPTION
#what
本番環境でアプリケーションを公開するために必要なデプロイ作業を自動化する。

#why
毎週開発状況を本番環境に反映させて動作確認をするためデプロイ作業も毎週行わなければならないが、その際にデプロイを自動化していると非常に簡便であるため。