### PR TITLE
ユーザー新規登録/ログイン/サーバー(sns連携、facebook)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 .byebug_history
 public/uploads/* 
 config/secrets.yml
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,6 @@ gem 'owlcarousel-rails'
 gem 'fog-aws'
 gem 'ancestry'
 gem 'ransack'
+gem "omniauth"
+gem "omniauth-facebook"
+gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,9 +89,15 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubis (2.7.0)
     excon (0.67.0)
     execjs (2.7.0)
+    faraday (0.17.0)
+      multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     fog-aws (3.5.2)
       fog-core (~> 2.1)
@@ -125,6 +131,7 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
+    hashie (3.6.0)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -142,6 +149,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jwt (2.2.1)
     kgio (2.11.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -161,6 +169,8 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.12.2)
     multi_json (1.14.1)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
     mysql2 (0.5.2)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
@@ -168,6 +178,20 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
+    oauth2 (1.4.2)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    omniauth (1.9.0)
+      hashie (>= 3.4.6, < 3.7.0)
+      rack (>= 1.6.2, < 3)
+    omniauth-facebook (5.0.0)
+      omniauth-oauth2 (~> 1.2)
+    omniauth-oauth2 (1.6.0)
+      oauth2 (~> 1.1)
+      omniauth (~> 1.9)
     orm_adapter (0.5.0)
     owlcarousel-rails (2.2.3.5)
     polyamorous (2.3.0)
@@ -289,6 +313,7 @@ DEPENDENCIES
   carrierwave
   coffee-rails (~> 4.2)
   devise
+  dotenv-rails
   fog-aws
   font-awesome-rails
   gretel
@@ -298,6 +323,8 @@ DEPENDENCIES
   listen (~> 3.0.5)
   mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
+  omniauth
+  omniauth-facebook
   owlcarousel-rails
   pry-rails
   puma (~> 3.0)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -2,29 +2,45 @@
 
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # You should configure your model like this:
-  # devise :omniauthable, omniauth_providers: [:twitter]
+  devise :omniauthable, omniauth_providers: [:twitter]
 
   # You should also create an action method in this controller like this:
-  # def twitter
-  # end
+  def twitter
+  end
 
   # More info at:
   # https://github.com/plataformatec/devise#omniauth
 
   # GET|POST /resource/auth/twitter
-  # def passthru
-  #   super
-  # end
+  def passthru
+    super
+  end
 
   # GET|POST /users/auth/twitter/callback
-  # def failure
-  #   super
-  # end
+  def failure
+    super
+  end
+  def facebook
+    # You need to implement the method below in your model (e.g. app/models/user.rb)
+    @user = User.from_omniauth(request.env["omniauth.auth"])
 
-  # protected
+    if @user.persisted?
+      sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
+      set_flash_message(:notice, :success, :kind => "Facebook") if is_navigational_format?
+    else
+      session["devise.facebook_data"] = request.env["omniauth.auth"]
+      redirect_to new_user_registration_url
+    end
+  end
 
-  # The path used when OmniAuth fails
-  # def after_omniauth_failure_path_for(scope)
-  #   super(scope)
-  # end
+  def failure
+    redirect_to root_path
+  end
+
+  protected
+
+  The path used when OmniAuth fails
+  def after_omniauth_failure_path_for(scope)
+    super(scope)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
-         
+         :recoverable, :rememberable, :validatable,
+         :omniauthable
     has_one :card
     has_one :shipping
     has_many :items, dependent: :destroy
@@ -11,4 +11,36 @@ class User < ApplicationRecord
     # has_many :comments
     # has_many :reviews
 
+    # def self.from_omniauth(auth)
+    #   where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+    #     user.email = auth.info.email
+    #     user.password = Devise.friendly_token[0,20]
+    #     user.name = auth.info.name   # assuming the user model has a name
+    #     user.image = auth.info.image
+    #   end  
+    # end    
+    def self.from_omniauth(auth)
+      user = User.where(email: auth.info.email).first
+      if user
+        return user
+      else
+        where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+          # userモデルが持っているカラムをそれぞれ定義していく
+          user.email = auth.info.email
+          user.password = Devise.friendly_token[0,20]
+          user.nickname = auth.info.nickname
+          user.first_name = auth.info.first_name
+          user.last_name = auth.info.last_name
+          user.first_kana = auth.info.first_kana
+          user.last_kana = auth.info.last_kana
+          user.birthday = auth.info.birthday
+          user.uid = auth.uid
+          user.provider = auth.provider
+  
+          # If you are using confirmable and the provider(s) you use validate emails,
+          # uncomment the line below to skip the confirmation emails.
+          user.skip_confirmation!
+        end
+      end
+    end
 end

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -4,7 +4,7 @@
       %h1
         = link_to new_user_registration_path, class: "logo" do
           =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?465897195", size: "193x49", alt: "mercari"
-
+       
     %main.single-container__main
       %section.l-single-container
         %h2.l-single-container__head.registration 新規会員登録
@@ -13,7 +13,7 @@
             = link_to new_user_registration_path, class: "btn-default btn-mail" do
               %i.fa.fa-envelope
               %p メールアドレスで登録する 
-            %button#facebook-login.btn-default.btn-sns.btn-sns-facebook
+            = link_to user_facebook_omniauth_authorize_path, id: "facebook-login", class: "btn-default btn-sns btn-sns-facebook" do
               %i.fa.fa-facebook-square
               %p Facebookで登録する
             %button#google-login.btn-default.btn-sns.btn-sns-google

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -296,4 +296,7 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+
+#   config.omniauth :facebook, ENV["FACEBOOK_API_KEY"], ENV["FACEBOOK_SECRET_KEY"], scope: 'email', info_fields: 'email, name'
+  config.omniauth :facebook, ENV["FACEBOOK_API_KEY"], ENV["FACEBOOK_SECRET_KEY"], scope: 'email', info_fields: 'email, name'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
-  devise_for :users, controllers:{
+  devise_for :users, controllers: {
       sessions: 'users/sessions',
-      registrations: 'users/registrations'
+      registrations: 'users/registrations',
+      omniauth_callbacks: 'users/omniauth_callbacks'
     }
   root "items#index"
   #あとでcorectionをmemberに変える必要あるかも。そうすればurlにidが追加される。

--- a/db/migrate/20191107085823_add_fields_to_user.rb
+++ b/db/migrate/20191107085823_add_fields_to_user.rb
@@ -1,0 +1,7 @@
+class AddFieldsToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+    add_column :users, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191104102732) do
+ActiveRecord::Schema.define(version: 20191107085823) do
 
   create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",       null: false
@@ -91,7 +91,6 @@ ActiveRecord::Schema.define(version: 20191104102732) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name",                                              null: false
     t.string   "email",                                default: "", null: false
     t.string   "encrypted_password",                   default: "", null: false
     t.string   "reset_password_token"
@@ -113,8 +112,10 @@ ActiveRecord::Schema.define(version: 20191104102732) do
     t.string   "building"
     t.string   "nickname"
     t.string   "name"
+    t.string   "provider"
+    t.string   "uid"
+    t.string   "image"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["name"], name: "index_users_on_name", using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 


### PR DESCRIPTION
#what
facebookのSNS認証を利用してサインアップできるようにする。

#why
アプリケーションとFacebookが連携できることでサインアップやログインが簡易になり、さらに機能の共有も期待できるから。