### PR TITLE
ユーザー新規登録/ログイン/サーバー (sns認証)/google, facebook (修正)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,4 +74,5 @@ gem 'ancestry'
 gem 'ransack'
 gem "omniauth"
 gem "omniauth-facebook"
+gem 'omniauth-google-oauth2'
 gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,10 @@ GEM
       rack (>= 1.6.2, < 3)
     omniauth-facebook (5.0.0)
       omniauth-oauth2 (~> 1.2)
+    omniauth-google-oauth2 (0.8.0)
+      jwt (>= 2.0)
+      omniauth (>= 1.1.1)
+      omniauth-oauth2 (>= 1.6)
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
@@ -325,6 +329,7 @@ DEPENDENCIES
   mysql2 (>= 0.3.18, < 0.6.0)
   omniauth
   omniauth-facebook
+  omniauth-google-oauth2
   owlcarousel-rails
   pry-rails
   puma (~> 3.0)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -2,7 +2,7 @@
 
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # You should configure your model like this:
-  devise :omniauthable, omniauth_providers: [:twitter]
+  # devise :omniauthable, omniauth_providers: [:twitter]
 
   # You should also create an action method in this controller like this:
   def twitter
@@ -20,18 +20,50 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def failure
     super
   end
-  def facebook
-    # You need to implement the method below in your model (e.g. app/models/user.rb)
-    @user = User.from_omniauth(request.env["omniauth.auth"])
 
+  def facebook
+    callback_for(:facebook)
+  end
+
+  def google_oauth2
+    callback_for(:google)
+  end
+
+  def callback_for(provider)
+    @user = User.from_omniauth(request.env["omniauth.auth"])
     if @user.persisted?
-      sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
-      set_flash_message(:notice, :success, :kind => "Facebook") if is_navigational_format?
+      sign_in_and_redirect @user, event: :authentication #after_sign_in_path_forと同じパス
+      set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?
     else
-      session["devise.facebook_data"] = request.env["omniauth.auth"]
-      redirect_to new_user_registration_url
+      session["devise.#{provider}_data"] = request.env["omniauth.auth"].except("extra")
+      redirect_to signup_registration_path
     end
   end
+  # def facebook
+  #   # You need to implement the method below in your model (e.g. app/models/user.rb)
+  #   @user = User.from_omniauth(request.env["omniauth.auth"])
+
+  #   if @user.persisted?
+  #     sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
+  #     set_flash_message(:notice, :success, :kind => "Facebook") if is_navigational_format?
+  #   else
+  #     session["devise.facebook_data"] = request.env["omniauth.auth"]
+  #     redirect_to new_user_registration_url
+  #   end
+  # end
+
+  # def google_oauth2
+  #   # You need to implement the method below in your model (e.g. app/models/user.rb)
+  #   @user = User.from_omniauth(request.env["omniauth.auth"])
+
+  #   if @user.persisted?
+  #     sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
+  #     set_flash_message(:notice, :success, :kind => "Google") if is_navigational_format?
+  #   else
+  #     session["devise.google_data"] = request.env["omniauth.auth"]
+  #     redirect_to new_user_registration_url
+  #   end
+  # end
 
   def failure
     redirect_to root_path
@@ -39,7 +71,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   protected
 
-  The path used when OmniAuth fails
+  # The path used when OmniAuth fails
   def after_omniauth_failure_path_for(scope)
     super(scope)
   end

--- a/app/models/sns_credential.rb
+++ b/app/models/sns_credential.rb
@@ -1,0 +1,3 @@
+class SnsCredential < ApplicationRecord
+  belongs_to :user, optional: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,22 +3,46 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :omniauthable
+         :omniauthable,omniauth_providers: [:facebook, :google_oauth2]
     has_one :card
     has_one :shipping
     has_many :items, dependent: :destroy
+    has_many :sns_credentials, dependent: :destroy
     # has_many :likes
     # has_many :comments
     # has_many :reviews
 
-    # def self.from_omniauth(auth)
-    #   where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
-    #     user.email = auth.info.email
-    #     user.password = Devise.friendly_token[0,20]
-    #     user.name = auth.info.name   # assuming the user model has a name
-    #     user.image = auth.info.image
-    #   end  
-    # end    
+    # def self.find_oauth(auth)
+    #   uid = auth.uid
+    #   provider = auth.provider
+    #   snscredential = SnsCredential.where(uid: uid, provider: provider).first
+    #   if snscredential.present?
+    #     user = User.where(id: snscredential.user_id).first
+    #   else
+    #     user = User.where(email: auth.info.email).first
+    #     if user.present?
+    #       SnsCredential.create(
+    #         uid: uid,
+    #         provider: provider,
+    #         user_id: user.id
+    #         )
+    #     else
+    #       user = User.create(
+    #         nickname: auth.info.name,
+    #         email:    auth.info.email,
+    #         password: Devise.friendly_token[0, 20],
+    #         telephone: "08000000000"
+    #         )
+    #       SnsCredential.create(
+    #         uid: uid,
+    #         provider: provider,
+    #         user_id: user.id
+    #         )
+    #     end
+    #   end
+    #   return user
+    # end
+
     def self.from_omniauth(auth)
       user = User.where(email: auth.info.email).first
       if user
@@ -39,7 +63,7 @@ class User < ApplicationRecord
   
           # If you are using confirmable and the provider(s) you use validate emails,
           # uncomment the line below to skip the confirmation emails.
-          user.skip_confirmation!
+          # user.skip_confirmation!
         end
       end
     end

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -8,12 +8,12 @@
       .login-panel
         .login-panel__no-account
           %p アカウントをお持ちでない方はこちら
-          = link_to "新規会員登録", new_user_registration_path, class: "btn-registration"
+          = link_to "新規会員登録", new_user_path, class: "btn-registration"
         .login-panel__form-inner.sns
-          %button#facebook-login.btn-default.btn-sns.btn-sns-facebook
+          = link_to user_facebook_omniauth_authorize_path, id: "facebook-login", class: "btn-default btn-sns btn-sns-facebook" do
             %i.fa.fa-facebook-square
             %p Facebookでログイン  
-          %button#google-login.btn-default.btn-sns.btn-sns-google
+          = link_to user_google_oauth2_omniauth_authorize_path, id: "google-login", class: "btn-default btn-sns btn-sns-google" do
             %i.fa.fa-google
             %p Googleでログイン
         = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|     

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -13,10 +13,10 @@
             = link_to new_user_registration_path, class: "btn-default btn-mail" do
               %i.fa.fa-envelope
               %p メールアドレスで登録する 
-            = link_to user_facebook_omniauth_authorize_path, id: "facebook-login", class: "btn-default btn-sns btn-sns-facebook" do
+            = link_to user_facebook_omniauth_authorize_path, class: "btn-default btn-sns btn-sns-facebook" do
               %i.fa.fa-facebook-square
               %p Facebookで登録する
-            %button#google-login.btn-default.btn-sns.btn-sns-google
+            = link_to user_google_oauth2_omniauth_authorize_path, class: "btn-default btn-sns btn-sns-google" do
               %i.fa.fa-google
               %p Googleで登録する
     %footer.new-phone-footer

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -2,3 +2,9 @@ server '18.176.106.68', user: 'ec2-user', roles: %w{app db web}
 
 set :rails_env, "production"
 set :unicorn_rack_env, "production"
+# set :ssh_options, {
+#   port: 3000,
+#   keys: [File.expand_path('~/.ssh/freemarket61d.pem')], #'~/.ssh/id_rsa'部分をローカル環境の鍵のパスに
+#   forward_agent: true,
+#   auth_methods: %w(publickey)
+# }

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -298,5 +298,9 @@ Devise.setup do |config|
   # config.sign_in_after_change_password = true
 
 #   config.omniauth :facebook, ENV["FACEBOOK_API_KEY"], ENV["FACEBOOK_SECRET_KEY"], scope: 'email', info_fields: 'email, name'
-  config.omniauth :facebook, ENV["FACEBOOK_API_KEY"], ENV["FACEBOOK_SECRET_KEY"], scope: 'email', info_fields: 'email, name'
+  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
+  config.omniauth :facebook, ENV['FACEBOOK_CLIENT_ID'], ENV['FACEBOOK_CLIENT_SECRET'] 
+  # config.omniauth :facebook, Rails.application.secrets.facebook_client_id, Rails.application.secrets.facebook_client_secret
+  # config.omniauth :google_oauth2, Rails.application.secrets.google_client_id, Rails.application.secrets.google_client_secret
 end
+

--- a/db/migrate/20191109113516_create_sns_credentials.rb
+++ b/db/migrate/20191109113516_create_sns_credentials.rb
@@ -1,0 +1,11 @@
+class CreateSnsCredentials < ActiveRecord::Migration[5.0]
+  def change
+    create_table :sns_credentials do |t|
+      t.string :uid
+      t.string :provider
+      t.integer :user_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191107085823) do
+ActiveRecord::Schema.define(version: 20191109113516) do
 
   create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",       null: false
@@ -86,6 +86,14 @@ ActiveRecord::Schema.define(version: 20191107085823) do
 
   create_table "sizes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "sns_credentials", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "uid"
+    t.string   "provider"
+    t.integer  "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
#what
googleのdevelopper登録及びSNS認証の実装とfacebookのSNS認証機能の修正

#why
facebookに続きgoogleでも新規登録及びログインを可能にするため。facebookはエラーが見られたため。