### PR TITLE
商品検索フロント＆サーバー

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,4 @@ gem "omniauth-facebook"
 gem "omniauth-google-oauth2"
 gem 'dotenv-rails'
 gem 'payjp'
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,18 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jwt (2.2.1)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     kgio (2.11.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -340,6 +352,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari
   listen (~> 3.0.5)
   mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)

--- a/app/assets/stylesheets/_items_search.scss
+++ b/app/assets/stylesheets/_items_search.scss
@@ -1,0 +1,178 @@
+.search-wrapper {
+  width: 100%;
+  .search-products {
+    padding: 42px 0px 100px;
+    margin: 0px auto 0;
+    width: 1040px;
+    &-type {
+      margin-top: 60px;
+      &__top {
+        display: block;
+        box-sizing: border-box;
+        justify-content: space-between;
+        position: relative;
+        .search-theme {
+          flex: 1 1 0%;
+          font-family: Arial,游ゴシック体,YuGothic,メイリオ,Meiryo,sans-serif;
+          font-size: 24px;
+          font-weight: 600;
+          line-height: 1.4em;
+          margin: 10px;
+          width: 929px;
+        }
+      }
+      .search-items-block {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        width: 1044px;
+        .search-items-list {
+          position: relative;
+          background-color: #fff;
+          margin: 10px;
+          width: 188px;
+          height: 252px;
+          &:hover {
+            opacity: 0.5;
+          }
+          .search-items-list-link {
+            width: 100%;
+            .search-items-image {
+              width: 100%;
+            }
+            .search-items-detail {
+              box-sizing: border-box;
+              color: #222;
+              font-size: 14px;
+              height: 64px;
+              line-height: 1.4em;
+              padding: 0 12px;
+              white-space: normal;
+              word-break: break-word;
+            }
+            .search-items-price {
+                z-index: 2;
+                position: absolute;
+                height: 0;
+                overflow: hidden;
+                padding: 0 0 90px;
+                left: 0px;
+                bottom: 10px;
+                .search-price-yen {
+                  margin: 0;
+                  padding: 0 12px;
+                  height: 28px;
+                  letter-spacing: .02em;
+                  display: inline-flex;
+                  font-size: 17px;
+                  align-items: center;
+                  background: rgba(0,0,0,.4);
+                  border-radius: 0 14px 14px 0;
+                  bottom: 8px;
+                  color: #fff;
+                }
+              }
+              .search-items-name {
+                display: inline-block;
+                height: 2.8em;
+                overflow: hidden;
+                position: relative;
+              }
+          }
+        }
+      }
+    }
+    .search-paginate{
+      text-align: center;
+      nav.pagination{
+        height: 50px;
+        span.page.current{
+          width: 44px;
+          height: 44px;
+          display: inline-block;
+          border: 1px solid #ccc;
+          border-radius: 4px;
+          line-height: 42px;
+          font-size: 14px;
+          color: #fff;
+          background-color: #ea352d;
+      
+        }
+        span.page{
+          width: 44px;
+          height: 44px;
+          display: inline-block;
+          border: 1px solid #ccc;
+          border-radius: 4px;
+          line-height: 42px;
+          font-size: 14px;
+          background-color: #fff;
+          a{
+            text-decoration: none;
+            color :#333;
+          }
+        }
+        span.next{
+          width: 44px;
+          height: 44px;
+          display: inline-block;
+          border: 1px solid #ccc;
+          border-radius: 4px;
+          line-height: 42px;
+          font-size: 18px;
+          text-decoration: none;
+          background-color: #fff;
+          a{
+            text-decoration: none;
+            color :rgb(80, 77, 77);
+          }
+        }
+        span.last{
+          width: 44px;
+          height: 44px;
+          display: inline-block;
+          border: 1px solid #ccc;
+          border-radius: 4px;
+          line-height: 42px;
+          font-size: 18px;
+          text-decoration: none;
+          background-color: #fff;
+          a{
+            text-decoration: none;
+            color :rgb(80, 77, 77);
+          }
+        }
+        span.first{
+          width: 44px;
+          height: 44px;
+          display: inline-block;
+          border: 1px solid #ccc;
+          border-radius: 4px;
+          line-height: 42px;
+          font-size: 18px;
+          text-decoration: none;
+          background-color: #fff;
+          a{
+            text-decoration: none;
+            color :rgb(80, 77, 77);
+          }
+        }
+        span.prev{
+          width: 44px;
+          height: 44px;
+          display: inline-block;
+          border: 1px solid #ccc;
+          border-radius: 4px;
+          line-height: 42px;
+          font-size: 18px;
+          text-decoration: none;
+          background-color: #fff;
+          a{
+            text-decoration: none;
+            color :rgb(80, 77, 77);
+          }
+        }       
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,6 +11,7 @@
 @import "items_new";
 @import "items_buy";
 @import "items_show";
+@import "items_search";
 @import "sidebar";
 @import "shared/header";
 @import "shared/sell";

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -102,6 +102,11 @@ class ItemsController < ApplicationController
   def done
   end
 
+  def item_search
+    @items = Item.where('name LIKE(?)', "%#{params[:name]}%").page(params[:page]).per(20).order("created_at DESC")
+    @search_name = params[:name]
+  end
+
   private
 
   def item_params

--- a/app/views/items/item_search.html.haml
+++ b/app/views/items/item_search.html.haml
@@ -1,0 +1,25 @@
+.search-wrapper
+  = render 'shared/header'
+  .search-body
+    .search-body__contents
+      .search-products
+        .search-products-type
+          .search-products-type__top
+            %h3.search-theme
+              = "「#{@search_name}」の検索結果"
+          .search-items-block
+            - @items.each do |item|
+              .search-items-list
+                = link_to "/items/#{item.id}", class: "search-items-list-link" do
+                  = image_tag item.images[0].image_url.url, alt: 'search-items-image', height: '188px', width: '188px', class: 'items-image'
+                  .search-items-detail
+                    .search-items-price
+                      %span.search-price-yen
+                        = converting_to_jpy(item.price)
+                    %h3.search-items-name
+                      = item.name
+        .search-paginate
+          = paginate @items
+
+  = render 'shared/sell'
+  = render 'shared/aside_and_footer'

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,0 +1,10 @@
+-#  Link to the "First" page
+-#  available local variables
+-#    url:           url to the first page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+-# t('views.pagination.first').html_safe
+%span.first
+  = link_to_unless current_page.first?, "<<", url, remote: remote

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -1,0 +1,8 @@
+-#  Non-link tag that stands for skipped pages...
+-#  available local variables
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span.page.gap
+  = t('views.pagination.truncate').html_safe

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,0 +1,10 @@
+-#  Link to the "Last" page
+-#  available local variables
+-#    url:           url to the last page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+-# t('views.pagination.last').html_safe
+%span.last
+  = link_to_unless current_page.last?, ">>", url, remote: remote

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,0 +1,10 @@
+-#  Link to the "Next" page
+-#  available local variables
+-#    url:           url to the next page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+-# t('views.pagination.next').html_safe
+%span.next
+  = link_to_unless current_page.last?, ">", url, rel: 'next', remote: remote 

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -1,0 +1,10 @@
+-#  Link showing page number
+-#  available local variables
+-#    page:          a page object for "this" page
+-#    url:           url to this page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span{class: "page#{' current' if page.current?}"}
+  = link_to_unless page.current?, page, url, {remote: remote, rel: page.rel}

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -1,0 +1,18 @@
+-#  The container tag
+-#  available local variables
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+-#    paginator:     the paginator that renders the pagination tags inside
+= paginator.render do
+  %nav.pagination
+    = first_page_tag unless current_page.first?
+    = prev_page_tag unless current_page.first?
+    - each_page do |page|
+      - if page.display_tag?
+        = page_tag page
+      - elsif !page.was_truncated?
+        = gap_tag
+    = next_page_tag unless current_page.last?
+    = last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,0 +1,10 @@
+-#  Link to the "Previous" page
+-#  available local variables
+-#    url:           url to the previous page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+-# t('views.pagination.previous').html_safe
+%span.prev
+  = link_to_unless current_page.first?, "<<", url, rel: 'prev', remote: remote

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -6,9 +6,9 @@
           = image_tag 'mercari-logo.jpg', alt: 'mercari', height: '38px', width: '135px'
 
       .word-search
-        %form
-          %input.word-search__message{type: "search", value:"", placeholder:"何かお探しですか？"}
-          %button.word-search__btn{title: "検索", type: "submit"}
+        = form_tag( "/items/item_search", method: :get ) do 
+          = text_field_tag :name, "", class: "word-search__message", name: "name", placeholder: '何かお探しですか？'
+          = button_tag "", class: "word-search__btn" do
             = fa_icon 'search', alt: 'search', width: '16px', height: '16px', class: 'search-icon'
 
     .header__index__bottom

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
       get 'done'
     end
     collection do
+      get 'item_search'
       get 'category_child', defaults: { format: 'json' }
       get 'category_gchild', defaults: { format: 'json' }
     end


### PR DESCRIPTION
# 実装内容
## フロント
- ヘッダーのinputをform＿tag仕様に変更
- 一覧が表示されるviewページ作成
- 検索結果のタイトルにキーワード表示
- 一応ページネーションもできるようにしてます

## サーバー
- itemのnameからキーワードあいまい検索でitemデータを引っ張る

## その他
- gem　kaminari　の追加
