### PR TITLE
ユーザーマイページ(メールパスワード、発送元)編集/フロント、サーバー(バリデーションエラーメッセージ含む)

### DIFF
--- a/app/assets/javascripts/jquery.validation.handler.js
+++ b/app/assets/javascripts/jquery.validation.handler.js
@@ -80,7 +80,7 @@ $(function(){
         error.insertAfter(element);
     }
  });
-})  
+});
 
 $(function(){
   $.validator.addMethod("firstKana", function(value, element, regexpr) {          
@@ -180,7 +180,7 @@ $(function(){
       }
   }   
  });
-}) 
+});
 
 $(function(){
   $.validator.addMethod("firstKana", function(value, element, regexpr) {          
@@ -264,7 +264,7 @@ $(function(){
         error.insertAfter(element);
     }
  });
-})  
+});
 
 $(function(){
   $.validator.addMethod("password", function(value, element, regexpr) {          

--- a/app/controllers/shippings_controller.rb
+++ b/app/controllers/shippings_controller.rb
@@ -37,4 +37,5 @@ class ShippingsController < ApplicationController
   def set_shipping
     @shipping = Shipping.find_by(user_id: current_user.id)
   end
+  
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -45,6 +45,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def configure_sign_up_params
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :nickname, :first_name, :last_name, :first_kana, :last_kana, :birthday, :birthyear, :birthmonth])
   end
+  
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params
   #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -28,6 +28,6 @@
               パスワードを設定したい場合は上記をすべて入力してください。（設定しない場合は空欄）
           .form-group
             = f.submit "変更する", class: "btn-default btn-red btn-shipping"
-  = render "shared/sidebar"
+= render "shared/sidebar"
 = render 'shared/sell'
 = render 'shared/aside_and_footer'

--- a/app/views/shippings/edit.html.haml
+++ b/app/views/shippings/edit.html.haml
@@ -47,7 +47,7 @@
             = f.text_field :phone_number, class: "input-default", placeholder: "例) 09012345678"        
           .form-group
             = f.submit "変更する", class: "btn-default btn-red btn-shipping"
-  = render "shared/sidebar"
+= render "shared/sidebar"
 = render 'shared/sell'
 = render 'shared/aside_and_footer'
 


### PR DESCRIPTION
#what
ユーザーマイページのメール/パスワードと発送元の編集画面のフロント及びサーバーと、バリデーションエラーメッセージを実装した。

#why
利用者が最初に登録した情報に変更があった場合にいつでも情報を編集できるようにしておくため。