### PR TITLE
商品購入ページのボタン遷移先修正

### DIFF
--- a/app/assets/stylesheets/_items_show.scss
+++ b/app/assets/stylesheets/_items_show.scss
@@ -287,7 +287,7 @@
         
         &__text {
           &__user {
-            margin: 0px 0px 5px 30px;
+            margin: 0px 0px 5px 20px;
             font-weight: 600;
           }
           &__main {
@@ -751,7 +751,7 @@
         
         &__text {
           &__user {
-            margin: 0px 0px 5px 30px;
+            margin: 0px 0px 5px 20px;
             font-weight: 600;
           }
           &__main {

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -15,6 +15,11 @@ class CardsController < ApplicationController
     redirect_to action: "index" if card.exists?
   end
 
+  def newbuy
+    card = Card.where(user_id: current_user.id)
+    redirect_to action: "index" if card.exists?
+  end
+
   def create
     card = Card.where(user_id: current_user.id)
     Payjp.api_key = 'sk_test_0e21a1a16d0a0e377209db69'
@@ -26,12 +31,15 @@ class CardsController < ApplicationController
       metadata: {user_id: current_user.id}
       )
       @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
-      if @card.save
-        redirect_to action: "index"
-      else
-        redirect_to action: "create"
-      end
+      @card.save
     end
+    @item = Item.new
+    @item = Item.find_by(params[:id])
+    if request.referer.include?("/newbuy")
+      redirect_to "/items/#{@item.id}/buy"
+    else request.referer.include?("/new/")
+      redirect_to action: "index"
+    end  
   end
 
   def destroy #PayjpとCardのデータベースを削除

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -76,6 +76,7 @@ class ItemsController < ApplicationController
   end
 
   def buy
+    @user = User.find(current_user.id)
     @card = Card.where(user_id: current_user.id).first if Card.where(user_id: current_user.id).present?
     if @card.present?
       Payjp.api_key = "sk_test_0e21a1a16d0a0e377209db69"

--- a/app/controllers/shippings_controller.rb
+++ b/app/controllers/shippings_controller.rb
@@ -1,6 +1,5 @@
 class ShippingsController < ApplicationController
-  
-  before_action :set_shipping, only: [:edit, :update]
+  before_action :set_shipping, only: [:edit, :editbuy, :update]
 
   def new
     @shipping = Shipping.new
@@ -19,11 +18,18 @@ class ShippingsController < ApplicationController
     @shipping = Shipping.find_by(user_id: current_user.id)
   end
 
+  def editbuy
+    @shipping = Shipping.find_by(user_id: current_user.id)
+  end
+
   def update
-    if @shipping.update(shipping_params)
-      redirect_to edit_shipping_path(current_user.id), notice: '変更しました'
-    else
-      render :edit
+    @shipping.update(shipping_params)
+    @item = Item.new
+    @item = Item.find_by(params[:id])
+    if request.referer.include?("/editbuy")
+      redirect_to "/items/#{@item.id}/buy"
+    else request.referer.include?("/edit/")
+      redirect_to edit_shipping_path(current_user.id)
     end  
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,7 @@ class UsersController < ApplicationController
 
   def update
     @user.update(update_user_params)
-    redirect_to action: :index
+    redirect_to request.referer
   end
 
   def destroy

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,22 +1,22 @@
 class Prefecture < ActiveHash::Base
 
   self.data = [
-    {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
-    {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
-    {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},
-    {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, {id: 12, name: '千葉県'},
-    {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, {id: 15, name: '新潟県'},
-    {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, {id: 18, name: '福井県'},
-    {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, {id: 21, name: '岐阜県'},
-    {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, {id: 24, name: '三重県'},
-    {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, {id: 27, name: '大阪府'},
-    {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, {id: 30, name: '和歌山県'},
-    {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, {id: 33, name: '岡山県'},
-    {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, {id: 36, name: '徳島県'},
-    {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, {id: 39, name: '高知県'},
-    {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, {id: 42, name: '長崎県'},
-    {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, {id: 45, name: '宮崎県'},
-    {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
+    {name: '北海道'}, {name: '青森県'}, {name: '岩手県'},
+    {name: '宮城県'}, {name: '秋田県'}, {name: '山形県'},
+    {name: '福島県'}, {name: '茨城県'}, {name: '栃木県'},
+    {name: '群馬県'}, {name: '埼玉県'}, {name: '千葉県'},
+    {name: '東京都'}, {name: '神奈川県'}, {name: '新潟県'},
+    {name: '富山県'}, {name: '石川県'}, {name: '福井県'},
+    {name: '山梨県'}, {name: '長野県'}, {name: '岐阜県'},
+    {name: '静岡県'}, {name: '愛知県'}, {name: '三重県'},
+    {name: '滋賀県'}, {name: '京都府'}, {name: '大阪府'},
+    {name: '兵庫県'}, {name: '奈良県'}, {name: '和歌山県'},
+    {name: '鳥取県'}, {name: '島根県'}, {name: '岡山県'},
+    {name: '広島県'}, {name: '山口県'}, {name: '徳島県'},
+    {name: '香川県'}, {name: '愛媛県'}, {name: '高知県'},
+    {name: '福岡県'}, {name: '佐賀県'}, {name: '長崎県'},
+    {name: '熊本県'}, {name: '大分県'}, {name: '宮崎県'},
+    {name: '鹿児島県'}, {name: '沖縄県'}
    ]
 
 end

--- a/app/views/cards/newbuy.html.haml
+++ b/app/views/cards/newbuy.html.haml
@@ -1,0 +1,78 @@
+= render partial: 'shared/header'
+.mypage-container-new-card
+  .new-card-container
+    = form_tag(cards_path, method: :post, id: 'charge-form',  name: "inputForm") do
+      .new-card-head
+        .new-card-head__title
+          クレジットカード情報入力
+      .new-card-container
+        .new-card-container__center
+          .new-card-container__center__num
+            .new-card-container__center__num--label
+              カード番号
+            .new-card-container__center__num--required
+              必須
+          .new-card-container__center__input-num
+            = text_field_tag "number", "", class: "number", placeholder: "半角数字のみ" ,maxlength: "16", type: "text", id: "card_number", class: "card_number"
+          .new-card-container__center__icon-area
+            %ul.card-list
+              %li
+              = image_tag "//www-mercari-jp.akamaized.net/assets/img/card/visa.svg?465897195", width: "49px",height: "20px", class: "card-icons"
+              %li
+              = image_tag "//www-mercari-jp.akamaized.net/assets/img/card/master-card.svg?465897195", width: "34px",height: "20px" , class: "card-icons"
+              %li
+              = image_tag "//www-mercari-jp.akamaized.net/assets/img/card/saison-card.svg?465897195", width: "32px",height: "20px" , class: "card-icons"
+              %li
+              = image_tag "//www-mercari-jp.akamaized.net/assets/img/card/jcb.svg?465897195", width: "32px",height: "20px" , class: "card-icons"
+              %li
+              = image_tag "//www-mercari-jp.akamaized.net/assets/img/card/american_express.svg?465897195", width: "21px",height: "20px" , class: "card-icons"
+              %li
+              = image_tag "//www-mercari-jp.akamaized.net/assets/img/card/dinersclub.svg?465897195", width: "32px",height: "20px" , class: "card-icons"
+              %li
+              = image_tag "//www-mercari-jp.akamaized.net/assets/img/card/discover.svg?465897195", width: "32px",height: "20px" , class: "card-icons"
+          .new-card-container__center__exp
+            .new-card-container__center__exp--label
+              有効期限
+            .new-card-container__center__exp--required
+              必須
+          .new-card-container__center__input-exp
+            %select#exp_month{name: "exp_month", type: "text", class: "exp_month"}
+              %option{value: ""} --
+              %option{value: "1"}01
+              %option{value: "2"}02
+              %option{value: "3"}03
+              %option{value: "4"}04
+              %option{value: "5"}05
+              %option{value: "6"}06
+              %option{value: "7"}07
+              %option{value: "8"}08
+              %option{value: "9"}09
+              %option{value: "10"}10
+              %option{value: "11"}11
+              %option{value: "12"}12
+            %span 月
+            %select#exp_year{name: "exp_year", type: "text", class: "exp_year"}
+              %option{value: ""} --
+              %option{value: "2019"}19
+              %option{value: "2020"}20
+              %option{value: "2021"}21
+              %option{value: "2022"}22
+              %option{value: "2023"}23
+              %option{value: "2024"}24
+              %option{value: "2025"}25
+              %option{value: "2026"}26
+              %option{value: "2027"}27
+              %option{value: "2028"}28
+              %option{value: "2029"}29
+            %span 年
+          .new-card-container__center__cvc
+            .new-card-container__center__cvc--label
+              セキュリティコード
+            .new-card-container__center__cvc--required
+              必須
+          .new-card-container__center__input-cvc
+            = text_field_tag "cvc", "", class: "cvc", placeholder: "カード背面3~4桁の番号", maxlength: "4", id: "cvc"
+          .new-card-container__center__btn-area
+            #card_token
+              = submit_tag "追加する", id: "token_submit", class: "new-card-btn"
+  = render 'shared/sidebar'

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -60,7 +60,7 @@
         - else
           登録なし
         .confirmation-addres__edit
-          = link_to "変更する >",edit_user_path(current_user.id), class: "confirmation-addres-btn"
+          = link_to "変更する >",edit_shipping_path(current_user.id), class: "confirmation-addres-btn"
     .confirmation-payment-method
       .confirmation-method
         .confirmation-method__label

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -46,17 +46,17 @@
       .confirmation-addres
         .confirmation-addres__label
           配送先
-        - if @item.user.shipping.present?
+        - if @user.shipping.present?
           .confirmation-addres__post
-            = "〒#{@item.user.shipping.postal_code}"
+            = "〒#{@user.shipping.postal_code}"
           .confirmation-addres__city
-            = @item.user.shipping.prefectures
-            = @item.user.shipping.city
-            = @item.user.shipping.address
-            = @item.user.shipping.building
+            = @user.shipping.prefectures
+            = @user.shipping.city
+            = @user.shipping.address
+            = @user.shipping.building
           .confirmation-addres__name
-            = @item.user.shipping.first_name
-            = @item.user.shipping.last_name
+            = @user.shipping.first_name
+            = @user.shipping.last_name
         - else
           登録なし
         .confirmation-addres__edit

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -60,7 +60,7 @@
         - else
           登録なし
         .confirmation-addres__edit
-          = link_to "変更する >",edit_shipping_path(current_user.id), class: "confirmation-addres-btn"
+          = link_to "変更する >",editbuy_shipping_path(@item.id), class: "confirmation-addres-btn"
     .confirmation-payment-method
       .confirmation-method
         .confirmation-method__label

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -60,7 +60,7 @@
         - else
           登録なし
         .confirmation-addres__edit
-          = link_to "変更する >","/", class: "confirmation-addres-btn"
+          = link_to "変更する >",edit_user_path(current_user.id), class: "confirmation-addres-btn"
     .confirmation-payment-method
       .confirmation-method
         .confirmation-method__label

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -77,7 +77,7 @@
           登録なし
         .fix-box
         .confirmation-method__edit
-          = link_to "変更する >", new_card_path, class: "confirmation-edit-btn"
+          = link_to "変更する >", newbuy_card_path(@item.id), class: "confirmation-edit-btn"
 
     .confirmation-foot-field
       .footer-menu

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -61,7 +61,7 @@
       = link_to "購入画面へ進む", "/items/#{@item.id}/buy", class:"buybtn"
     .item-container__item-description
       .item-container__item-description__inner
-        = @item.discription
+        = simple_format(@item.discription)
     .item-container__fixbox
   -if @item.user_id == current_user.id
     .seller-box

--- a/app/views/shared/_sidebar.html.haml
+++ b/app/views/shared/_sidebar.html.haml
@@ -30,7 +30,7 @@
         %i.fa.fa-chevron-right
     %li.setting 設定
     %li.profile
-      = link_to profile_user_path(id: current_user.id), class:"side-list" do
+      = link_to profile_user_path(current_user.id), class:"side-list" do
         %p プロフィール
         %i.fa.fa-chevron-right
     %li.shipping

--- a/app/views/shippings/edit.html.haml
+++ b/app/views/shippings/edit.html.haml
@@ -28,7 +28,7 @@
             = f.label "都道府県" 
             %span.form-require 必須
             %i.fa.fa-angle-down
-            = f.collection_select :prefectures, Prefecture.all, :id, :name, {include_blank: "--"}, {class:"input-edit"}
+            = f.collection_select :prefectures, Prefecture.all, :name, :name, {include_blank: "--"}, {class:"input-edit"}
           .form-group
             = f.label "市区町村" 
             %span.form-require 必須

--- a/app/views/shippings/editbuy.html.haml
+++ b/app/views/shippings/editbuy.html.haml
@@ -1,0 +1,50 @@
+= render partial: 'shared/header'
+- breadcrumb :personinfo
+= render partial: 'shared/gretel'
+.mypage-container-edit.shipping-editbuy
+  .ide-container
+    .identification-head
+      %h1 発送元・お届け先住所変更
+    .identification-container
+      = form_for @shipping, class: 'l-single-inner registration-form', id: "registration-field" do |f|
+        .l-single-container__content
+          .form-group
+            %div
+              = f.label "お名前"    
+              %span.form-require 必須
+              = f.text_field :first_name, class: "input-default", placeholder: "例) 山田"
+              = f.text_field :last_name, class: "input-default", placeholder: "例) 彩"
+          .form-group    
+            %div
+              = f.label "お名前カナ"    
+              %span.form-require 必須
+              = f.text_field :first_kana, class: "input-default", placeholder: "例) ヤマダ"
+              = f.text_field :last_kana, class: "input-default", placeholder: "例) アヤ"
+          .form-group
+            = f.label "郵便番号" 
+            %span.form-require 必須
+            = f.text_field :postal_code, class: "input-default", placeholder: "例) 123-4567"
+          .form-group.prefecture
+            = f.label "都道府県" 
+            %span.form-require 必須
+            %i.fa.fa-angle-down
+            = f.collection_select :prefectures, Prefecture.all, :name, :name, {include_blank: "--"}, {class:"input-edit"}
+          .form-group
+            = f.label "市区町村" 
+            %span.form-require 必須
+            = f.text_field :city, class: "input-default", placeholder: "例) 横浜市緑区"
+          .form-group
+            = f.label "番地" 
+            %span.form-require 必須
+            = f.text_field :address, class: "input-default", placeholder: "例) 青山1-1-1"  
+          .form-group
+            = f.label "建物名" 
+            %span.form-require.option 任意
+            = f.text_field :building, class: "input-default", placeholder: "例) 柳ビル103"   
+          .form-group
+            = f.label "電話" 
+            %span.form-require.option 任意
+            = f.text_field :phone_number, class: "input-default", placeholder: "例) 09012345678"        
+          .form-group
+            = f.submit "変更する", class: "btn-default btn-red btn-shipping"
+  = render "shared/sidebar"

--- a/app/views/shippings/new.html.haml
+++ b/app/views/shippings/new.html.haml
@@ -45,7 +45,7 @@
             = f.label "都道府県" 
             %span.form-require 必須
             %i.fa.fa-angle-down
-            = f.collection_select :prefectures, Prefecture.all, :id, :name, {include_blank: "--"}, {class:"input-edit"}
+            = f.collection_select :prefectures, Prefecture.all, :name, :name, {include_blank: "--"}, {class:"input-edit"}
           .form-group
             = f.label "市区町村" 
             %span.form-require 必須

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -25,7 +25,7 @@
           .identification-container__birthday__label
             %p 生年月日
           .identification-container__birthday__box
-            = @user.birthday.delete("[]").gsub(/[""]/){''}
+            = "#{@user.birthyear}/#{@user.birthmonth}/#{@user.birthday}"
         .identification-container__postnum
           .identification-container__postnum__label
             .identification-container__postnum__label__info

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -41,7 +41,7 @@
             .identification-container__prefecture__label__optional
               %p 任意
           .identification-container__prefecture__box
-            = f.collection_select :prefectures, Prefecture.all, :id, :name, {}, {class:"input-edit"}
+            = f.collection_select :prefectures, Prefecture.all, :name, :name, {}, {class:"input-edit"}
             = fa_icon 'angle-down', alt: 'angle-down', class: "fas fa-angle-dowx fa-2x", id:"prefectures-angle"
         .identification-container__city
           .identification-container__city__label

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,11 @@ Rails.application.routes.draw do
       get 'category_gchild', defaults: { format: 'json' }
     end
   end
-  resources :cards, only: [:index, :new, :create, :destroy]
+  resources :cards, only: [:index, :new, :create, :destroy] do
+    member do
+      get 'newbuy'
+    end
+  end
   resources :shippings, only: [:new, :create, :edit, :update, :destroy] do
     member do
       get 'editbuy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,9 +34,12 @@ Rails.application.routes.draw do
       get 'category_gchild', defaults: { format: 'json' }
     end
   end
-  resources :cards, only: [:index, :new, :create, :destroy] do
+  resources :cards, only: [:index, :new, :create, :destroy]
+  resources :shippings, only: [:new, :create, :edit, :update, :destroy] do
+    member do
+      get 'editbuy'
+    end
   end
-  resources :shippings, only: [:new, :create, :edit, :update, :destroy]
   resources :brands, only: :index
   resources :categories, only: [:show, :new]
   resources :images, only: :destroy, defaults: { format: 'json' }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 20191116092236) do
+ActiveRecord::Schema.define(version: 20191116112925) do
 
   create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",       null: false


### PR DESCRIPTION
# what
商品購入ページのボタン遷移先修正

# why
送り先住所の変更の遷移先から商品購入ページへ戻るように修正
クレジットカード未登録の場合の変更の遷移先から商品購入ページへ戻るように修正